### PR TITLE
Fix navigation bugs

### DIFF
--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -223,7 +223,11 @@ public:
   //@}
   
 protected:
-
+  enum TransformResult {
+    TRANS_FAILURE = -1,
+    TRANS_SUCEESS = 0,
+    TRANS_NEED_REPLAN_GLOBAL_PATH = 1,
+  };
   /**
     * @brief Update internal obstacle vector based on occupied costmap cells
     * @remarks All occupied cells will be added as point obstacles.
@@ -316,10 +320,10 @@ protected:
     * @param[out] tf_plan_to_global Transformation between the global plan and the global planning frame
     * @return \c true if the global plan is transformed, \c false otherwise
     */
-  bool transformGlobalPlan(const tf2_ros::Buffer& tf, const std::vector<geometry_msgs::PoseStamped>& global_plan,
-                           const geometry_msgs::PoseStamped& global_pose,  const costmap_2d::Costmap2D& costmap,
-                           const std::string& global_frame, double max_plan_length, std::vector<geometry_msgs::PoseStamped>& transformed_plan,
-                           int* current_goal_idx = NULL, geometry_msgs::TransformStamped* tf_plan_to_global = NULL) const;
+  TransformResult transformGlobalPlan(const tf2_ros::Buffer& tf, const std::vector<geometry_msgs::PoseStamped>& global_plan,
+                                      const geometry_msgs::PoseStamped& global_pose,  const costmap_2d::Costmap2D& costmap,
+                                      const std::string& global_frame, double max_plan_length, std::vector<geometry_msgs::PoseStamped>& transformed_plan,
+                                      int* current_goal_idx = NULL, geometry_msgs::TransformStamped* tf_plan_to_global = NULL);
     
   /**
     * @brief Estimate the orientation of a pose from the global_plan that is treated as a local goal for the local planner.

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -1211,8 +1211,9 @@ bool TebOptimalPlanner::isTrajectoryFeasible(base_local_planner::CostmapModel* c
 {
   if (look_ahead_idx < 0 || look_ahead_idx >= teb().sizePoses())
     look_ahead_idx = teb().sizePoses() - 1;
-  
-  for (int i=0; i <= look_ahead_idx; ++i)
+
+  // Note by Tony: allow move from obstacles.
+  for (int i=1; i <= look_ahead_idx; ++i)
   {           
     if ( costmap_model->footprintCost(teb().Pose(i).x(), teb().Pose(i).y(), teb().Pose(i).theta(), footprint_spec, inscribed_radius, circumscribed_radius) == -1 )
     {

--- a/src/timed_elastic_band.cpp
+++ b/src/timed_elastic_band.cpp
@@ -392,7 +392,7 @@ bool TimedElasticBand::initTrajectoryToGoal(const std::vector<geometry_msgs::Pos
     for (int i=1; i<(int)plan.size()-1; ++i)
     {
         double yaw;
-        if (estimate_orient)
+        if (estimate_orient && 0)
         {
             // get yaw from the orientation of the distance vector between pose_{i+1} and pose_{i}
             double dx = plan[i+1].pose.position.x - plan[i].pose.position.x;

--- a/src/timed_elastic_band.cpp
+++ b/src/timed_elastic_band.cpp
@@ -392,19 +392,8 @@ bool TimedElasticBand::initTrajectoryToGoal(const std::vector<geometry_msgs::Pos
     for (int i=1; i<(int)plan.size()-1; ++i)
     {
         double yaw;
-        if (estimate_orient && 0)
-        {
-            // get yaw from the orientation of the distance vector between pose_{i+1} and pose_{i}
-            double dx = plan[i+1].pose.position.x - plan[i].pose.position.x;
-            double dy = plan[i+1].pose.position.y - plan[i].pose.position.y;
-            yaw = std::atan2(dy,dx);
-            if (backwards)
-                yaw = g2o::normalize_theta(yaw+M_PI);
-        }
-        else 
-        {
-            yaw = tf::getYaw(plan[i].pose.orientation);
-        }
+        yaw = tf::getYaw(plan[i].pose.orientation);
+
         PoseSE2 intermediate_pose(plan[i].pose.position.x, plan[i].pose.position.y, yaw);
         double dt = estimateDeltaT(BackPose(), intermediate_pose, max_vel_x, max_vel_theta);
         addPoseAndTimeDiff(intermediate_pose, dt);


### PR DESCRIPTION
1.Send global planning request when local planning is not feasible.
2.global path replanning problem: Change global replanning rate to 0 and inform the global planner to replan when detecting obstacle on the global path.
3.Fix bugs:
Fixes RockRobo/RoboticFloorScrubber#267
Fixes RockRobo/RoboticFloorScrubber#274
Fixes RockRobo/RoboticFloorScrubber#378
Fixes RockRobo/RoboticFloorScrubber#381