### PR TITLE
fix: Fix bug about goto task not replan with obstacle.

### DIFF
--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -758,7 +758,7 @@ TebLocalPlannerROS::TransformResult TebLocalPlannerROS::transformGlobalPlan(cons
         continue;
 
       if(costmap_->worldToMap(newer_pose.pose.position.x, newer_pose.pose.position.y, x0, y0)
-              && costmap_model_->pointCost(x0, y0) == -1.0)
+              && costmap_->getCost(x0, y0) > 127)
       {
         is_find_obstacle = true;
       }


### PR DESCRIPTION
Change the condition for checking obstacle in teb_local_planner from
only lethal to lethal, inscribed, or possibly circumscribed. That is,
when the cost of the path point > 127, there is an obstacle on the path.

[Issue] RockRobo/RoboticFloorScrubber#527